### PR TITLE
Update requirements.yml

### DIFF
--- a/workshop_ee/requirements.yml
+++ b/workshop_ee/requirements.yml
@@ -9,3 +9,4 @@ collections:
   - name: community.mysql
   - name: containers.podman
   - name: infra.controller_configuration
+  - name: community.crypto


### PR DESCRIPTION
adding community.crypto to get of an error:

```
TASK [../../roles/gitlab_server : Git Post | Configure SSL] ********************
ERROR! couldn't resolve module/action 'get_certificate'. This often indicates a misspelling, missing collection, or incorrect module path.
The error appears to be in '/runner/project/roles/gitlab_server/tasks/certbot.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
---
- name: git pre | check to see if SSL cert already applied
```