### PR TITLE
Update requirements.yml

### DIFF
--- a/workshop_ee/requirements.yml
+++ b/workshop_ee/requirements.yml
@@ -10,3 +10,4 @@ collections:
   - name: containers.podman
   - name: infra.controller_configuration
   - name: community.crypto
+  - name: chocolatey.chocolatey


### PR DESCRIPTION
adding chocolatey.chocolatey

to fix this error
```
TASK [include_role : ../../roles/windows_ws_setup] *****************************
ERROR! couldn't resolve module/action 'chocolatey.chocolatey.win_chocolatey'. This often indicates a misspelling, missing collection, or incorrect module path.
The error appears to be in '/runner/project/roles/windows_ws_setup/tasks/chrome.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
---
- name: install Chocolatey
  ^ here
```