### PR TITLE
Update requirements.yml

### DIFF
--- a/workshop_ee/requirements.yml
+++ b/workshop_ee/requirements.yml
@@ -11,3 +11,4 @@ collections:
   - name: infra.controller_configuration
   - name: community.crypto
   - name: chocolatey.chocolatey
+  - name: community.windows


### PR DESCRIPTION
fixing error

```
ERROR! couldn't resolve module/action 'community.windows.win_iis_webapplication'. This often indicates a misspelling, missing collection, or incorrect module path.
The error appears to be in '/runner/project/roles/windows_ws_setup/tasks/myrtille.yml': line 55, column 3, but may
be elsewhere in the file depending on the exact syntax problem
```